### PR TITLE
Fix snp-pileup crash: Allocate the right amount of memory

### DIFF
--- a/inst/extcode/snp-pileup.cpp
+++ b/inst/extcode/snp-pileup.cpp
@@ -223,7 +223,7 @@ int program_main(arguments arguments) {
 	mplp_aux_t **data;
 	data = (mplp_aux_t **) calloc(n, sizeof(mplp_aux_t*)); // allocate memory for data
 	for (i = 0; i < n; ++i) {
-		data[i] = (mplp_aux_t*) calloc(1, sizeof(mplp_aux_t*));
+		data[i] = (mplp_aux_t*) calloc(1, sizeof(mplp_aux_t));
 
 		// open file
 		hFILE *hfp = hopen(arguments.args[i + 2], "r");


### PR DESCRIPTION
On our data, `snp-pileup` was crashing immediately, with valgrind showing:

```
==36323== Invalid write of size 8
==36323==    at 0x4029DB: program_main(arguments) (snp-pileup.cpp:252)
==36323==    by 0x404063: main (snp-pileup.cpp:527)
==36323==  Address 0x6067e58 is 0 bytes after a block of size 8 alloc'd
==36323==    at 0x4C267BB: calloc (vg_replace_malloc.c:593)
==36323==    by 0x4027E3: program_main(arguments) (snp-pileup.cpp:226)
==36323==    by 0x404063: main (snp-pileup.cpp:527)
```

This is a simple memory allocation bug, fixed by this PR. It was probably also the cause of #34.