### PR TITLE
properly order the jointseg

### DIFF
--- a/R/facets-segment.R
+++ b/R/facets-segment.R
@@ -169,6 +169,8 @@ segsnps <- function(mat, cval=25, hetscale=FALSE, delta=0) {
 jointsegsummary <- function(jointseg) {
     # remove snps with NA in segs (due to NA in cnlr)
     jointseg <- jointseg[is.finite(jointseg$seg),]
+    # properly order the data
+    jointseg <- jointseg[order(jointseg$seg, jointseg$chrom, jointseg$maploc), ]
     # initialize output table
     nsegs <- max(jointseg$seg)
     # segment start and end indices and number of loci


### PR DESCRIPTION
An error occurred when I run facets with mouse genome data `Error in seg.start[seg]:seg.end[seg] : NA/NaN argument`.

After I debug, I found that the `jointseg` in the modified function is not properly ordered. This makes `seg.start <- which(diff(c(0, jointseg$seg)) == 1)` failed.

```r
Browse[3]> nsegs
[1] 2487
Browse[3]> length(seg.start )
[1] 2484
```

