### PR TITLE
adding line in procSnps() to ensure required field order

### DIFF
--- a/R/facets-procreads.R
+++ b/R/facets-procreads.R
@@ -12,6 +12,8 @@ procSnps <- function(rcmat, ndepth=35, het.thresh=0.25, snp.nbhd=250, nX=23, unm
     row.names(rcmat) <- NULL # reset row names so that it's 1:nsnps
     rcmat$NOR.RD = 1 - rcmat$NOR.RD/rcmat$NOR.DP
     rcmat$TUM.RD = 1 - rcmat$TUM.RD/rcmat$TUM.DP
+    # ensure rcmat fields in required order
+    rcmat <- rcmat[,c('Chromosome','Position','NOR.DP','NOR.RD','TUM.DP','TUM.RD')] 
     names(rcmat) = c("chrom", "maploc", "rCountN", "vafN", "rCountT", "vafT")
     # make chromosome ordered and numeric
     rcmat$chrom <- as.numeric(ordered(rcmat$chrom, levels = chromlevels))


### PR DESCRIPTION
In procSnps(), the rcmat data.frame must have columns in a specific order before its fields are renamed. My SNP matrix from snp-pileup did not match this order, causing depth data to be interpreted as vaf data, resulting in 0 het-SNPs being identified. I added a line to procSnps() to make sure the fields are in the correct order before they are renamed, so that the function can accept input data with arbitrary field order.